### PR TITLE
Git config with GPG signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,16 @@ make install
 > The symlinks are linked by their extension. If the file only contain a `.symlink`
 > extension they are placed in the $HOME dir as a dotfile.
 
+## Setting up Git
+
+Once you've ran the `install` it's time to set up Git with your credentials.
+
+    git config --global user.name "Your Name"
+    git config --global user.email "you@email.com"
+
+Then if possible [tell git about your GPG key][gpg-key]. Once this is ready you
+are good to go.
+
 ## macOS
 
 If you want to install my macOS settings just run the following command:
@@ -57,3 +67,4 @@ make install-hombrew
 [MIT License][mit] as usual!
 
 [mit]: https://github.com/albertogg/dotfiles/blob/master/LICENSE
+[gpg-key]: https://help.github.com/articles/telling-git-about-your-gpg-key/

--- a/README.md
+++ b/README.md
@@ -24,26 +24,19 @@ Running the install script will do the following:
 
     make install
 
-> The symlinks are linked by their extension. If the file only contain a `.symlink`
-> extension they are placed in the $HOME dir as a dotfile.
+> The symlinks are linked by their extension. If the file only contain a
+> `.symlink` extension they are placed in the $HOME dir as a dotfile.
 
 ## Setting up Git
 
-Once you've ran the `install` it's time to set up Git with your credentials.
+Once the install finishes it's time to set up Git with your credentials. Either
+copy your current user credentials to `~/.gitconfig.local` or set them globally.
 
     git config --global user.name "Your Name"
     git config --global user.email "you@email.com"
 
 Then if possible [tell git about your GPG key][gpg-key]. Once this is ready you
-are good to go. If you are not planning on signing your commits you'll need to
-remove the following option from the `.gitconfig`:
-
-    [commit]
-        gpgsign = true
-
-or set it to false doing:
-
-    git config --global commit.gpgsign false
+are good to go.
 
 ## macOS
 
@@ -51,7 +44,7 @@ If you want to install my macOS settings just run the following command:
 
     make macos
 
-It's based on Mathias Bynens `http://mths.be/osx`.
+Those settings are based on Mathias Bynens `http://mths.be/osx`.
 
 ## Hombrew
 

--- a/README.md
+++ b/README.md
@@ -12,9 +12,7 @@ Dependencies needed for the installation.
 
 Simply clone the repo.
 
-```sh
-git clone https://github.com/albertogg/dotfiles.git ~/.dotfiles
-```
+    git clone https://github.com/albertogg/dotfiles.git ~/.dotfiles
 
 Running the install script will do the following:
 
@@ -24,9 +22,7 @@ Running the install script will do the following:
 - Create the golang workspace `~/go`
 - Install `vim-plug` and all vim plugins
 
-```sh
-make install
-```
+    make install
 
 > The symlinks are linked by their extension. If the file only contain a `.symlink`
 > extension they are placed in the $HOME dir as a dotfile.
@@ -39,15 +35,21 @@ Once you've ran the `install` it's time to set up Git with your credentials.
     git config --global user.email "you@email.com"
 
 Then if possible [tell git about your GPG key][gpg-key]. Once this is ready you
-are good to go.
+are good to go. If you are not planning on signing your commits you'll need to
+remove the following option from the `.gitconfig`:
+
+    [commit]
+        gpgsign = true
+
+or set it to false doing:
+
+    git config --global commit.gpgsign false
 
 ## macOS
 
 If you want to install my macOS settings just run the following command:
 
-```sh
-make macos
-```
+    make macos
 
 It's based on Mathias Bynens `http://mths.be/osx`.
 
@@ -58,9 +60,7 @@ install my default Homebrew Apps (git, coreutils, tree, rbenv, tmux, etc...)
 
 To achieve this you can use this command:
 
-```sh
-make install-hombrew
-```
+    make install-hombrew
 
 ## License
 

--- a/brew/caskfile.sh
+++ b/brew/caskfile.sh
@@ -8,6 +8,7 @@ install_casks() {
     brew cask install --appdir="/Applications" dropbox
     brew cask install --appdir="/Applications" transmission
     brew cask install --appdir="/Applications" gitup
+    brew cask install --appdir="/Applications" gpgtools-beta
 
     # clean
     brew cask cleanup

--- a/git/gitconfig.symlink
+++ b/git/gitconfig.symlink
@@ -14,7 +14,6 @@
 	counts = !git shortlog -sn
 	count-branch = "!f() { git log $1..$2 --pretty=oneline | wc -l; }; f"
 [core]
-	editor = vim
 	autocrlf = input
 	excludesfile = ~/.gitignore
 [user]

--- a/git/gitconfig.symlink
+++ b/git/gitconfig.symlink
@@ -1,9 +1,6 @@
-[user]
-	name = Alberto Grespan
-	email = alberto@albertogrespan.com
-	signingkey = 99E748E76A0B181F
-[credential]
-	helper = osxkeychain
+# Local/private config goes in the include
+[include]
+	path = ~/.gitconfig.local
 [alias]
 	g = grep -Ii
 	co = checkout
@@ -37,7 +34,3 @@
 	clean = git-lfs clean %f
 	smudge = git-lfs smudge %f
 	required = true
-[gpg]
-	program = gpg2
-[commit]
-	gpgsign = true

--- a/git/gitconfig.symlink
+++ b/git/gitconfig.symlink
@@ -39,3 +39,5 @@
 	required = true
 [gpg]
 	program = gpg2
+[commit]
+	gpgsign = true

--- a/git/gitconfig.symlink
+++ b/git/gitconfig.symlink
@@ -37,3 +37,5 @@
 	clean = git-lfs clean %f
 	smudge = git-lfs smudge %f
 	required = true
+[gpg]
+	program = gpg2

--- a/git/gitconfig.symlink
+++ b/git/gitconfig.symlink
@@ -1,18 +1,18 @@
 [alias]
 	co = checkout
 	cob = checkout -b
-	st = status
-	sts = status -s
+	g = grep -Ii
 	lg = log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr)%C(bold blue)<%an>%Creset' --abbrev-commit
 	fu = fetch upstream
-	rename = branch -m
-	conflicts = diff --name-only --diff-filter=UDX
 	dw = diff --word-diff
-	unstage = reset HEAD --
 	dc = diff --cached
-	g = grep -Ii
-	count = "!f() { git log $1..$2 --pretty=oneline | wc -l; }; f"
+	rename = branch -m
 	discard = checkout --
+	unstage = reset HEAD --
+	conflicts = diff --name-only --diff-filter=UDX
+	count = !git log --pretty=oneline | wc -l
+	counts = !git shortlog -sn
+	count-branch = "!f() { git log $1..$2 --pretty=oneline | wc -l; }; f"
 [core]
 	editor = vim
 	autocrlf = input
@@ -33,7 +33,7 @@
 [fetch]
 	prune = true
 	[branch]
-	autosetuprebase = always
+		autosetuprebase = always
 [filter "lfs"]
 	clean = git-lfs clean %f
 	smudge = git-lfs smudge %f

--- a/git/gitconfig.symlink
+++ b/git/gitconfig.symlink
@@ -1,34 +1,34 @@
+[user]
+	name = Alberto Grespan
+	email = alberto@albertogrespan.com
+	signingkey = 99E748E76A0B181F
+[credential]
+	helper = osxkeychain
 [alias]
+	g = grep -Ii
 	co = checkout
 	cob = checkout -b
-	g = grep -Ii
 	lg = log --color --graph --pretty=format:'%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr)%C(bold blue)<%an>%Creset' --abbrev-commit
 	fu = fetch upstream
 	dw = diff --word-diff
 	dc = diff --cached
 	rename = branch -m
-	discard = checkout --
 	unstage = reset HEAD --
+	discard = checkout --
 	conflicts = diff --name-only --diff-filter=UDX
 	count = !git log --pretty=oneline | wc -l
-	counts = !git shortlog -sn
 	count-branch = "!f() { git log $1..$2 --pretty=oneline | wc -l; }; f"
-[core]
-	autocrlf = input
-	excludesfile = ~/.gitignore
-[user]
-	name = Alberto Grespan
-	email = alberto@albertogrespan.com
-	signingkey = 3021C312
-[push]
-	default = current
+	counts = shortlog -sn
 [color]
 	diff = auto
 	status = auto
 	branch = auto
 	ui = true
-[credential]
-	helper = osxkeychain
+[core]
+	autocrlf = input
+	excludesfile = ~/.gitignore
+[push]
+	default = current
 [fetch]
 	prune = true
 	[branch]


### PR DESCRIPTION
Add the necessary configuration for Git commit signing by default using GPG and update instructions in the README to properly setup git after installing the dotfiles.